### PR TITLE
Make limiter great again!

### DIFF
--- a/back/api/routes.js
+++ b/back/api/routes.js
@@ -34,10 +34,6 @@ const apiLimiter = rateLimit({
   handler: (req, res, next) => { // function to handle requests once the max limit is exceeded
     events.emit('request.limit', { userId: req.userId, ip: req.ip });
     req.log.warn(`Too many requests from user: ${req.userId}, ip: ${req.ip}`);
-    if (req.userId) {
-      next();
-      return;
-    }
     res.status(429).send('Too many requests, please try again later.');
   }
 });


### PR DESCRIPTION
Prevent calling next middleware, even if request has correct userId.  Simply send unfriendly message with status(429).
Give equal opportunities to everyone :)

![image](https://user-images.githubusercontent.com/49561596/226136814-ac22e7c0-ffa6-4d29-8d08-b04eb9b03a7d.png)

