### PR TITLE
Make limiter great again!

### DIFF
--- a/back/api/routes.js
+++ b/back/api/routes.js
@@ -34,10 +34,6 @@ const apiLimiter = rateLimit({
   handler: (req, res, next) => { // function to handle requests once the max limit is exceeded
     events.emit('request.limit', { userId: req.userId, ip: req.ip });
     req.log.warn(`Too many requests from user: ${req.userId}, ip: ${req.ip}`);
-    if (req.userId) {
-      next();
-      return;
-    }
     res.status(429).send('Too many requests, please try again later.');
   }
 });


### PR DESCRIPTION
Prevent calling next middleware in api limiter, even if request has correct userId. Just send unfriendly message with status (429).
Give equal opportunities to everyone :)))

![image](https://user-images.githubusercontent.com/49561596/228529692-2c874b82-38fb-49f7-aed8-51dd9690c378.png)



